### PR TITLE
[UNDERTOW-1880] Fix graceful shutdown to work in HTTP/2 proxy modes

### DIFF
--- a/core/src/main/java/io/undertow/server/handlers/GracefulShutdownHandler.java
+++ b/core/src/main/java/io/undertow/server/handlers/GracefulShutdownHandler.java
@@ -92,13 +92,9 @@ public class GracefulShutdownHandler implements HttpHandler {
 
     @Override
     public void handleRequest(HttpServerExchange exchange) throws Exception {
-        boolean rejectDuringShutdown = true;
-
+        // Track Http2 channels to be able to perform the shutdown procedure
+        // defined in RFC9113 using GOAWAY frames.
         if (exchange.getConnection() instanceof Http2ServerConnection) {
-            rejectDuringShutdown = false;
-
-            // Track Http2 channels to be able to perform the shutdown procedure
-            // defined in RFC9113 using GOAWAY frames.
             Http2Channel channel = ((Http2ServerConnection) exchange.getConnection()).getChannel();
 
             if (http2Channels.add(channel)) {
@@ -108,16 +104,16 @@ public class GracefulShutdownHandler implements HttpHandler {
                 channel.addCloseTask(new ChannelListener<Http2Channel>() {
                         @Override
                         public void handleEvent(Http2Channel c) {
-                            http2Channels.remove(c);
-                            decrementActiveAndCheckShutdownComplete();
+                            if (http2Channels.remove(c)) {
+                                decrementActiveAndCheckShutdownComplete();
+                            }
                         }
                     });
             }
-
         }
 
         long snapshot = stateUpdater.updateAndGet(this, incrementActive);
-        if (isShutdown(snapshot) && rejectDuringShutdown) {
+        if (isShutdown(snapshot)) {
             decrementActiveAndCheckShutdownComplete();
             exchange.setStatusCode(StatusCodes.SERVICE_UNAVAILABLE);
             exchange.endExchange();
@@ -147,7 +143,8 @@ public class GracefulShutdownHandler implements HttpHandler {
 
     public void start() {
         synchronized (lock) {
-            stateUpdater.updateAndGet(this, current -> current & ACTIVE_COUNT_MASK);
+            http2Channels.clear();
+            stateUpdater.set(this, 0);
             for (ShutdownListener listener : shutdownListeners) {
                 listener.shutdown(false);
             }


### PR DESCRIPTION
The graceful shutdown handler bypassed 503 rejection for HTTP/2 connections, relying solely on GOAWAY. This failed in h2/h2c proxy modes where the proxy-to-backend connection is HTTP/2 and the proxy does not respect GOAWAY.

Changes:
- Always reject requests with 503 during shutdown regardless of protocol; GOAWAY remains as an additional signal to HTTP/2 clients
- Guard channel close task to only decrement active count if the channel is still tracked, preventing underflow after start()
- Reset state fully in start(), clearing tracked HTTP/2 channels so shutdown/start cycles work correctly

The tests passes now:
```
mvn test -pl core -Dtest=GracefulShutdownTestCase -DfailIfNoTests=false
mvn test -pl core -Dtest=GracefulShutdownTestCase -Dtest.proxy=true -DfailIfNoTests=false
mvn test -pl core -Dtest=GracefulShutdownTestCase -Dtest.h2=true -DfailIfNoTests=false
mvn test -pl core -Dtest=GracefulShutdownTestCase -Dtest.h2c=true -DfailIfNoTests=false
mvn test -pl core -Dtest=GracefulShutdownTestCase -Dtest.https=true -DfailIfNoTests=false

or
mvn test -pl core
```